### PR TITLE
fix(CI): restore workflow triggers to defaults

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,7 +2,6 @@ name: Python package
 
 on:
   pull_request:
-    types: [opened, reopened]
     branches:
       ['dev', 'main']
 jobs:


### PR DESCRIPTION
- Restored pull request triggers to the default: opened, reopened, and synchronized states
- CI will now also trigger when the HEAD of the PR is updated. 
